### PR TITLE
pkgs/rbrowser: fix the installation of the desktopItem

### DIFF
--- a/pkgs/rbrowser/default.nix
+++ b/pkgs/rbrowser/default.nix
@@ -218,8 +218,8 @@ stdenvNoCC.mkDerivation rec {
   installPhase = ''
     install -Dm755 $src/bin/rbrowser $out/bin/rbrowser
 
-    install -dm755 $out/share/applications
-    ln -s ${desktopItem}/share/appications/* $out/share/applications/
+    mkdir -p $out/share
+    ln -s ${desktopItem}/share/applications $out/share/applications
   '';
 
   meta =


### PR DESCRIPTION
There was a typo while creating a symlink to the desktop item. I fixed the typo, and symlinked the entire directory as well.