### PR TITLE
Fix mkSoxinModule import

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,7 +1,7 @@
 { lib, self, home-manager, ... }:
 
 rec {
-  mkSoxinModule = import ./lib/mk-soxin-module.nix { inherit lib modules; };
+  mkSoxinModule = import ./mk-soxin-module.nix { inherit lib modules; };
   modules = import ./modules { inherit lib; };
   nixosSystem = import ./nixos-system.nix {
     inherit self lib home-manager;


### PR DESCRIPTION
#11 which was merged recently had a typo. This was causing build failures. 


`warning: 'nix flake info' is a deprecated alias for 'nix flake metadata'
building the system configuration...
trace: Warning: `stdenv.lib` is deprecated and will be removed in the next release. Please use `lib` instead. For more information see https://github.com/NixOS/nixpkgs/issues/108938
error: getting status of '/nix/store/a5xgx4830d3b7l1vbzz3wvjm6ycznc12-source/lib/lib': No such file or directory

       … while evaluating the attribute 'lib.mkSoxinModule'

       at /nix/store/a5xgx4830d3b7l1vbzz3wvjm6ycznc12-source/lib/default.nix:4:3:
`