### PR TITLE
Template: Make sure template builds

### DIFF
--- a/template/flake.nix
+++ b/template/flake.nix
@@ -5,7 +5,7 @@
     nixos.url = "nixpkgs/nixos-20.09";
     master.url = "nixpkgs/master";
     home-manager = {
-      url = "github:nix-community/home-manager";
+      url = "github:nix-community/home-manager/release-20.09";
       inputs.nixpkgs.follows = "nixos";
     };
     soxin = {


### PR DESCRIPTION
Template example fails to build on nixos 20.02 due to in compatibilities with home-manager. 
Error:
`undefined variable 'anything' at /nix/store/a66zgq83mmr405vygpnf32dp30lld2vc-source/nixos/default.nix:79:19`
 
https://github.com/nix-community/home-manager/issues/1894

Fix: Pins home-manager to the compatible version in template.