### PR TITLE
programs.rofi: update to latest home-manager; add i3 swap workspaces feature

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "futils": {
       "locked": {
-        "lastModified": 1605370193,
-        "narHash": "sha256-YyMTf3URDL/otKdKgtoMChu4vfVL3vCMkRqpGifhUn0=",
+        "lastModified": 1620759905,
+        "narHash": "sha256-WiyWawrgmyN0EdmiHyG2V+fqReiVi8bM9cRdMaKQOFg=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5021eac20303a61fafe17224c087f5519baed54d",
+        "rev": "b543720b25df6ffdfcf9227afafc5b8c1fabfae8",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1608681543,
-        "narHash": "sha256-6YNP8GBG0nhqLMQVkCBxRirTYaaGhI8gKCwgcJ5+sLc=",
+        "lastModified": 1621135068,
+        "narHash": "sha256-aPJlgosfLp3QtPDFLf/N7qNpIo5Q45MpYyzlaACL2G4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3627ec4de58d7fbda13c82dfec94eace10198f23",
+        "rev": "77188bcd6e2c6c7a99253b36f08ed7b65f2901d2",
         "type": "github"
       },
       "original": {
@@ -37,11 +37,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1608770327,
-        "narHash": "sha256-5vl/k5THxbozvRp7WJ3DztokEw5AaLUs6O6fALTFLNE=",
+        "lastModified": 1621294190,
+        "narHash": "sha256-8fBxLnwgBRXcIdjPw95Htjw5/MsZPQUuUD5K+xP3Rq0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f971e0754358bceb3192076e950fda48bf2b104d",
+        "rev": "17e3fb2e23fe147f93c301e7515214b73520415d",
         "type": "github"
       },
       "original": {

--- a/modules/programs/rofi/default.nix
+++ b/modules/programs/rofi/default.nix
@@ -69,11 +69,9 @@ in
 
         theme = cfg.theme.name;
 
-        extraConfig = ''
-          rofi.modi: ${cfg.modi}
-        '' + (optionalString (cfg.dpi != null) ''
-          rofi.dpi: ${cfg.dpi}
-        '');
+        extraConfig = {
+          inherit (cfg) modi dpi;
+        };
 
         font = "Source Code Pro for Powerline 9";
       };

--- a/modules/programs/rofi/default.nix
+++ b/modules/programs/rofi/default.nix
@@ -37,9 +37,10 @@ in
               Whether to enable i3 support for rofi.
 
               When enabled, you can set i3 bindings to the following commands:
-              exec ''${pkgs.rofi}/bin/rofi -show i3Workspaces
-              exec ''${pkgs.rofi}/bin/rofi -show i3RenameWorkspace
               exec ''${pkgs.rofi}/bin/rofi -show i3MoveContainer
+              exec ''${pkgs.rofi}/bin/rofi -show i3RenameWorkspace
+              exec ''${pkgs.rofi}/bin/rofi -show i3SwapWorkspaces
+              exec ''${pkgs.rofi}/bin/rofi -show i3Workspaces
             '';
           };
         };
@@ -57,9 +58,10 @@ in
   config = mkIf cfg.enable (mkMerge [
     {
       soxin.programs.rofi.modi = mkIf (cfg.i3.enable) {
-        i3Workspaces = "${pkgs.rofi-i3-support}/bin/i3-switch-workspaces";
-        i3RenameWorkspace = "${pkgs.rofi-i3-support}/bin/i3-rename-workspace";
         i3MoveContainer = "${pkgs.rofi-i3-support}/bin/i3-move-container";
+        i3RenameWorkspace = "${pkgs.rofi-i3-support}/bin/i3-rename-workspace";
+        i3SwapWorkspaces = "${pkgs.rofi-i3-support}/bin/i3-swap-workspaces";
+        i3Workspaces = "${pkgs.rofi-i3-support}/bin/i3-switch-workspaces";
       };
     }
 

--- a/modules/programs/rofi/default.nix
+++ b/modules/programs/rofi/default.nix
@@ -3,9 +3,6 @@
 with lib;
 let
   cfg = config.soxin.programs.rofi;
-
-  modi = concatStringsSep ","
-    (mapAttrsToList (n: v: if v == null then n else "${n}:${v}") cfg.modi);
 in
 {
   options = {
@@ -23,6 +20,9 @@ in
             modi name. If the attribute value is not null, its path is given to
             rofi.
           '';
+          apply = attrs:
+            builtins.concatStringsSep ","
+              (mapAttrsToList (n: v: if v == null then n else "${n}:${v}") attrs);
           example = {
             custom = "/some/custom/script.sh";
           };
@@ -70,7 +70,7 @@ in
         theme = cfg.theme.name;
 
         extraConfig = ''
-          rofi.modi: ${modi}
+          rofi.modi: ${cfg.modi}
         '' + (optionalString (cfg.dpi != null) ''
           rofi.dpi: ${cfg.dpi}
         '');

--- a/pkgs/rofi-i3-support/default.nix
+++ b/pkgs/rofi-i3-support/default.nix
@@ -24,6 +24,11 @@ stdenvNoCC.mkDerivation rec {
       --subst-var-by jq_bin ${jq}/bin/jq \
       --subst-var-by out_dir $out
 
+    substitute $src/i3-swap-workspaces.sh $out/bin/i3-swap-workspaces \
+      --subst-var-by i3-msg_bin ${i3}/bin/i3-msg \
+      --subst-var-by jq_bin ${jq}/bin/jq \
+      --subst-var-by out_dir $out
+
     substitute $src/i3-switch-workspaces.sh $out/bin/i3-switch-workspaces \
       --subst-var-by i3-msg_bin ${i3}/bin/i3-msg \
       --subst-var-by jq_bin ${jq}/bin/jq \
@@ -32,7 +37,6 @@ stdenvNoCC.mkDerivation rec {
     substitute $src/list-workspaces.sh $out/lib/list-workspaces.sh \
       --subst-var-by i3-msg_bin ${i3}/bin/i3-msg \
       --subst-var-by jq_bin ${jq}/bin/jq \
-      --subst-var-by with_swm ${if withSwm then "true" else "false"} \
       --subst-var-by out_dir $out
 
     chmod 755 $out/bin/*

--- a/pkgs/rofi-i3-support/i3-move-container.sh
+++ b/pkgs/rofi-i3-support/i3-move-container.sh
@@ -1,23 +1,23 @@
 #!/usr/bin/env bash
 #
-#  vim:ft=sh:
+# vim:ft=sh:tabstop=4:shiftwidth=4:softtabstop=4:noexpandtab
 #
-#  Copyright (c) 2010-2020 Wael Nasreddine <wael.nasreddine@gmail.com>
+# Copyright (c) 2010-2021 Wael Nasreddine <wael.nasreddine@gmail.com>
 #
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  (at your option) any later version.
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#  You should have received a copy of the GNU General Public License
-#  along with this program; if not, write to the Free Software
-#  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
-#  USA.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+# USA.
 #
 
 set -euo pipefail
@@ -25,11 +25,11 @@ set -euo pipefail
 source @out_dir@/lib/list-workspaces.sh
 
 if [[ -z "${*}" ]]; then
-  # we need the back and forth first
-  echo back_and_forth
-  # get the list of workspaces that are not empty
-  listWorkspaces
+	# we need the back and forth first
+	echo back_and_forth
+	# get the list of workspaces that are not empty
+	listWorkspaces
 else
-  # switch to the given workspace
-  @i3-msg_bin@ move container to workspace "${@}" >/dev/null
+	# switch to the given workspace
+	@i3-msg_bin@ move container to workspace "${@}" >/dev/null
 fi

--- a/pkgs/rofi-i3-support/i3-rename-workspace.sh
+++ b/pkgs/rofi-i3-support/i3-rename-workspace.sh
@@ -1,23 +1,23 @@
 #!/usr/bin/env bash
 #
-#  vim:ft=sh:
+# vim:ft=sh:tabstop=4:shiftwidth=4:softtabstop=4:noexpandtab
 #
-#  Copyright (c) 2010-2020 Wael Nasreddine <wael.nasreddine@gmail.com>
+# Copyright (c) 2010-2017 Wael Nasreddine <wael.nasreddine@gmail.com>
 #
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  (at your option) any later version.
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#  You should have received a copy of the GNU General Public License
-#  along with this program; if not, write to the Free Software
-#  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
-#  USA.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+# USA.
 #
 
 set -euo pipefail
@@ -25,9 +25,9 @@ set -euo pipefail
 source @out_dir@/lib/list-workspaces.sh
 
 if [[ -z "${*}" ]]; then
-  # print the name of the current workspace
-  @i3-msg_bin@ -t get_workspaces | @jq_bin@ -r '.[] | if .focused == true then .name else empty end'
+	# print the name of the current workspace
+	@i3-msg_bin@ -t get_workspaces | @jq_bin@ -r '.[] | if .focused == true then .name else empty end'
 else
-  # switch to the given workspace
-  @i3-msg_bin@ rename workspace to "${@}" >/dev/null
+	# switch to the given workspace
+	@i3-msg_bin@ rename workspace to "${@}" >/dev/null
 fi

--- a/pkgs/rofi-i3-support/i3-swap-workspaces.sh
+++ b/pkgs/rofi-i3-support/i3-swap-workspaces.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# vim:ft=sh:tabstop=4:shiftwidth=4:softtabstop=4:noexpandtab
+#
+# Copyright (c) 2021 Wael Nasreddine <wael.nasreddine@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+# USA.
+#
+
+set -euo pipefail
+
+source @out_dir@/lib/list-workspaces.sh
+
+if [[ -z "${*}" ]]; then
+	# get the list of workspaces that are not empty
+	listWorkspaces
+	exit 0
+fi
+
+# record the target workspace, and its output
+readonly target_workspace="$1"
+readonly target_output="$(@i3-msg_bin@ -t get_workspaces | @jq_bin@ -r ".[] | select(.name == \"$target_workspace\") | .output")"
+
+# figure out the source workspace and the output name
+readonly source_workspace="$(@i3-msg_bin@ -t get_workspaces | @jq_bin@ -r ".[] | select(.visible == true and .focused == true) | .name")"
+readonly source_output="$(@i3-msg_bin@ -t get_workspaces | @jq_bin@ -r ".[] | select(.visible == true and .focused == true) | .output")"
+
+# if the target_output is empty then the workspace does not exist so just
+# switch to it to create it on the same output. Or if both workspaces are on
+# the same output then just switch to it
+if [[ -z "${target_output:-}" ]] || [[ "${source_output}" == "${target_output}" ]]; then
+	@i3-msg_bin@ workspace "$target_workspace" >/dev/null
+	exit 0
+fi
+
+# swap them now
+@i3-msg_bin@ move workspace to output "$target_output" >/dev/null
+@i3-msg_bin@ workspace "$target_workspace" >/dev/null
+@i3-msg_bin@ move workspace to output "$source_output" >/dev/null

--- a/pkgs/rofi-i3-support/i3-switch-workspaces.sh
+++ b/pkgs/rofi-i3-support/i3-switch-workspaces.sh
@@ -1,23 +1,23 @@
 #!/usr/bin/env bash
 #
-#  vim:ft=sh:
+# vim:ft=sh:tabstop=4:shiftwidth=4:softtabstop=4:noexpandtab
 #
-#  Copyright (c) 2010-2020 Wael Nasreddine <wael.nasreddine@gmail.com>
+# Copyright (c) 2010-2018 Wael Nasreddine <wael.nasreddine@gmail.com>
 #
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  (at your option) any later version.
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#  You should have received a copy of the GNU General Public License
-#  along with this program; if not, write to the Free Software
-#  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
-#  USA.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+# USA.
 #
 
 set -euo pipefail
@@ -25,11 +25,11 @@ set -euo pipefail
 source @out_dir@/lib/list-workspaces.sh
 
 if [[ -z "${*}" ]]; then
-  # we need the back and forth first
-  echo back_and_forth
-  # get the list of workspaces that are not empty
-  listWorkspaces
+	# we need the back and forth first
+	echo back_and_forth
+	# get the list of workspaces that are not empty
+	listWorkspaces
 else
-  # switch to the given workspace
-  @i3-msg_bin@ workspace "${@}" >/dev/null
+	# switch to the given workspace
+	@i3-msg_bin@ workspace "${@}" >/dev/null
 fi

--- a/pkgs/rofi-i3-support/list-workspaces.sh
+++ b/pkgs/rofi-i3-support/list-workspaces.sh
@@ -1,68 +1,67 @@
 #!/usr/bin/env bash
 #
-#  vim:ft=sh:
+# vim:ft=sh:tabstop=4:shiftwidth=4:softtabstop=4:noexpandtab
 #
-#  Copyright (c) 2010-2020 Wael Nasreddine <wael.nasreddine@gmail.com>
+# Copyright (c) 2010-2020 Wael Nasreddine <wael.nasreddine@gmail.com>
 #
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  (at your option) any later version.
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#  You should have received a copy of the GNU General Public License
-#  along with this program; if not, write to the Free Software
-#  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
-#  USA.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+# USA.
 #
 
 containsElement () {
-  local e match="$1"
-  shift
-  for e; do [[ "$e" == "$match" ]] && return 0; done
-  return 1
+	local e match="$1"
+	shift
+	for e; do [[ "$e" == "$match" ]] && return 0; done
+	return 1
 }
 
 function listWorkspaces() {
-  local result current_workspace current_profile current_story dir elem file elem
+	local all_workspaces current_workspace dir elem elem file profile_name story story_name workspaces
 
-  # print out the list of currently active workspaces
-  result=( $(@i3-msg_bin@ -t get_workspaces | @jq_bin@ -r '.[] | if .focused == false then .name else empty end') )
+	# get the list of non-focused workspaces
+	all_workspaces=( $(@i3-msg_bin@ -t get_workspaces | @jq_bin@ -r '.[] | select(.focused == false) | .name') )
 
-  # compute the current profile and the current story
-  current_workspace="$( @i3-msg_bin@ -t get_workspaces | @jq_bin@ -r '.[] | if .focused == true then .name else empty end' )"
-  if echo "${current_workspace}" | grep -q '@'; then
-    current_profile="$( echo "${current_workspace}" | cut -d\@ -f1 )"
-    current_story="$( echo "${current_workspace}" | cut -d\@ -f2 )"
-  else
-    current_profile="${current_workspace}"
-  fi
+	# get the list of available profiles
+	for file in $(find "${HOME}/.zsh/profiles" -iregex '.*/[a-z]*\.zsh' | sort); do
+		elem="$(basename "${file}" .zsh)"
+		if ! containsElement "${elem}" "${all_workspaces[@]}"; then
+			all_workspaces=("${all_workspaces[@]}" "${elem}")
+		fi
+	done
 
-  # print out the list of available stories, but only if there's no active story
-  if @with_swm@; then
-    if [[ -z "${current_story:-}" ]]; then
-      for story in $(swm story list --name-only | grep "^${current_profile}/" | cut -d/ -f2-); do
-        elem="${current_profile}@${story}"
-        if ! containsElement "${elem}" "${result[@]}"; then
-          result+=("${elem}")
-        fi
-      done
-    fi
-  fi
+	# get the list of available stories
+	for story in $(swm story list --name-only); do
+		profile_name="$(echo "${story}" | cut -d/ -f1)"
+		story_name="$(echo "${story}" | cut -d/ -f2-)"
+		elem="${profile_name}@${story_name}"
+		if ! containsElement "${elem}" "${all_workspaces[@]}"; then
+			all_workspaces+=("${elem}")
+		fi
+	done
 
-  # print out the list of available profiles
-  for file in $(find "${HOME}/.zsh/profiles" -iregex '.*/[a-z]*\.zsh' | sort); do
-    elem="$(basename "${file}" .zsh)"
-    if ! containsElement "${elem}" "${result[@]}"; then
-      result=("${result[@]}" "${elem}")
-    fi
-  done
+	# sort the workspaces by putting first the non-story workspaces followed by the story workspaces
+	workspaces=( $(printf "%s\n" "${all_workspaces[@]}" | grep -v '@' | sort) $(printf "%s\n" "${all_workspaces[@]}" | grep '@' | sort) )
 
-  for elem in "${result[@]}"; do
-    echo "${elem}"
-  done
+	# compute the current workspace
+	current_workspace="$( @i3-msg_bin@ -t get_workspaces | @jq_bin@ -r '.[] | select(.focused == true) | .name' )"
+
+	for elem in "${workspaces[@]}"; do
+		if [[ "${elem}" == "${current_workspace}" ]]; then
+			continue
+		fi
+
+		echo "${elem}"
+	done
 }


### PR DESCRIPTION
Importing changes I did downstream to the Rofi support:
- It now supports home-manager's master branch, but broken on release 20.09).
- Added support for swapping i3 workspaces (similar to dynamic window managers).
- The list workspaces function have also been updated:
  - [rofi/i3-support: get the list of profiles and stories before sorting](https://github.com/kalbasit/soxincfg/commit/7a580d74d7b311d46ecf6be2a791b4448e655425)
  - [rofi/i3-support: include the list of all available stories from all profiles](https://github.com/kalbasit/soxincfg/commit/8a5fc98f698c70378af9a596725fd4153ea159e3)
  - [rofi/i3-support: exclude the current workspace from the printed list](https://github.com/kalbasit/soxincfg/commit/4d089a1bc6279b6f0f0eb8c58c9e2b672b187338#diff-624b4059df9856cf5204b36ffdbaa40d538514e4847768eb0e55a1de81523b8e)


NOTE: This was extracted from #29 and tested only in that branch.