### PR TITLE
[lib] nixosSystem: allow setting global/nixos/hm modules and update to latest HM

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -40,9 +40,7 @@
 
         overlays = import ./overlays;
 
-        nixosModules = (import ./modules) // {
-          soxin = import ./modules/soxin.nix;
-        };
+        nixosModules.soxin = import ./modules/soxin.nix;
 
         defaultTemplate = {
           path = ./template;

--- a/flake.nix
+++ b/flake.nix
@@ -40,7 +40,7 @@
 
         overlays = import ./overlays;
 
-        nixosModules.soxin = import ./modules/soxin.nix;
+        nixosModules = (import ./modules) // { soxin = import ./modules/soxin.nix; };
         nixosModule = self.nixosModules.soxin;
 
         defaultTemplate = {

--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,7 @@
         overlays = import ./overlays;
 
         nixosModules.soxin = import ./modules/soxin.nix;
+        nixosModule = self.nixosModules.soxin;
 
         defaultTemplate = {
           path = ./template;

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -3,8 +3,6 @@
 rec {
   mkSoxinModule = import ./mk-soxin-module.nix { inherit lib modules; };
   modules = import ./modules { inherit lib; };
-  nixosSystem = import ./nixos-system.nix {
-    inherit self lib home-manager;
-  };
+  nixosSystem = import ./nixos-system.nix { inherit self lib home-manager; };
   overlaysToPkgs = import ./overlays-to-pkgs.nix { inherit lib; };
 }

--- a/lib/nixos-system.nix
+++ b/lib/nixos-system.nix
@@ -26,12 +26,12 @@ with lib;
 let
   args' = removeAttrs args [
     "globalModules"
-    "nixosModules"
     "hmModules"
+    "nixosModules"
 
     "globalSpecialArgs"
-    "nixosSpecialArgs"
     "hmSpecialArgs"
+    "nixosSpecialArgs"
   ];
 in
 nixosSystem (recursiveUpdate args' {

--- a/lib/nixos-system.nix
+++ b/lib/nixos-system.nix
@@ -42,7 +42,7 @@ nixosSystem (recursiveUpdate args' {
     # the mode allows us to tell at what level we are within the modules.
     mode = "NixOS";
 
-    # send soxin to all NixOS modules
+    # send soxin down to NixOS.
     soxin = self;
   }
   # include the global special arguments.
@@ -74,7 +74,7 @@ nixosSystem (recursiveUpdate args' {
 
         # the mode allows us to tell at what level we are within the modules.
         mode = "home-manager";
-        # send soxin to all NixOS modules
+        # send soxin down to home-manager.
         soxin = self;
       }
       # include the global special arguments.

--- a/lib/nixos-system.nix
+++ b/lib/nixos-system.nix
@@ -56,7 +56,7 @@ nixosSystem (recursiveUpdate args' {
     # include the NixOS modules
     ++ nixosModules
     # include Soxin modules
-    ++ self.nixosModule
+    ++ (singleton self.nixosModule)
     # include home-manager modules
     ++ (singleton home-manager.nixosModules.home-manager)
     # configure Nix registry so users can find soxin
@@ -88,6 +88,6 @@ nixosSystem (recursiveUpdate args' {
         # include the home-manager modules
         ++ hmModules
         # include Soxin module
-        ++ self.nixosModule;
+        ++ (singleton self.nixosModule);
     });
 })

--- a/lib/nixos-system.nix
+++ b/lib/nixos-system.nix
@@ -1,43 +1,93 @@
 { self, lib, home-manager }:
 
-{ modules ? [ ], globalSpecialArgs ? { }, nixosSpecialArgs ? { }, hmSpecialArgs ? { }, ... } @ args:
-lib.nixosSystem (lib.recursiveUpdate (removeAttrs args [ "globalSpecialArgs" "nixosSpecialArgs" "hmSpecialArgs" ]) {
+with lib;
+
+{
+  # The global modules are included in both NixOS and home-manager.
+  globalModules ? [ ]
+
+  # Home-manager specific modules.
+, hmModules ? [ ]
+
+  # NixOS specific modules.
+, nixosModules ? [ ]
+
+  # The global extra arguments are included in both NixOS and home-manager.
+, globalSpecialArgs ? { }
+
+  # Home-manager specific extra arguments.
+, hmSpecialArgs ? { }
+
+  # NixOS specific extra arguments.
+, nixosSpecialArgs ? { }
+
+, ...
+} @ args:
+let
+  args' = removeAttrs args [
+    "globalModules"
+    "nixosModules"
+    "hmModules"
+
+    "globalSpecialArgs"
+    "nixosSpecialArgs"
+    "hmSpecialArgs"
+  ];
+in
+nixosSystem (recursiveUpdate args' {
   specialArgs = {
+    # send home-manager down to the NixOS modules
+    inherit home-manager;
+
+    # the mode allows us to tell at what level we are within the modules.
     mode = "NixOS";
+
+    # send soxin to all NixOS modules
     soxin = self;
-  } // globalSpecialArgs // nixosSpecialArgs;
+  }
+  # include the global special arguments.
+  // globalSpecialArgs
+  # include the NixOS special arguments.
+  // nixosSpecialArgs;
 
-  modules = modules ++ [
-    {
-      _module.args = { inherit home-manager; };
-    }
-
-    self.nixosModules.soxin
-
-    home-manager.nixosModules.home-manager
-    # Required when using flakes.
-    {
+  modules =
+    # include the global modules
+    globalModules
+    # include the NixOS modules
+    ++ nixosModules
+    # include all Soxin modules
+    ++ (builtins.attrValues self.nixosModules)
+    # include all home-manager modules
+    ++ (builtins.attrValues home-manager.nixosModules)
+    # configure Nix registry so users can find soxin
+    ++ singleton { nix.registry.soxin.flake = self; }
+    # configure home-manager
+    ++ (singleton {
+      # tell home-manager to use the global (as in NixOS system-level) pkgs and
+      # install all  user packages through the users.users.<name>.packages.
       home-manager.useGlobalPkgs = true;
       home-manager.useUserPackages = true;
-    }
 
-    # Override home-manager per-user submodule to add our own modules to it,
-    # and to pass the argument `mode`.
-    ({ config, ... }: {
-      options.home-manager.users = lib.mkOption {
-        type = lib.types.attrsOf (lib.types.submoduleWith {
-          modules = [
-            {
-              _module.args = { inherit home-manager; };
-            }
-            self.nixosModules.soxin
-          ];
-          specialArgs = {
-            mode = "home-manager";
-            soxin = self;
-          } // globalSpecialArgs // hmSpecialArgs;
-        });
-      };
-    })
-  ];
+      home-manager.extraSpecialArgs = {
+        # send home-manager down to the home-manager modules
+        inherit home-manager;
+
+        # the mode allows us to tell at what level we are within the modules.
+        mode = "home-manager";
+        # send soxin to all NixOS modules
+        soxin = self;
+      }
+      # include the global special arguments.
+      // globalSpecialArgs
+      # include the NixOS special arguments.
+      // hmSpecialArgs;
+
+      home-manager.sharedModules =
+        # include the global modules
+        globalModules
+        # include the home-manager modules
+        ++ hmModules
+        # include all Soxin modules
+        ++ (builtins.attrValues self.nixosModules);
+    });
 })

--- a/lib/nixos-system.nix
+++ b/lib/nixos-system.nix
@@ -55,10 +55,10 @@ nixosSystem (recursiveUpdate args' {
     globalModules
     # include the NixOS modules
     ++ nixosModules
-    # include all Soxin modules
-    ++ (builtins.attrValues self.nixosModules)
-    # include all home-manager modules
-    ++ (builtins.attrValues home-manager.nixosModules)
+    # include Soxin modules
+    ++ (singleton self.nixosModules.soxin)
+    # include home-manager modules
+    ++ (singleton home-manager.nixosModules.home-manager)
     # configure Nix registry so users can find soxin
     ++ singleton { nix.registry.soxin.flake = self; }
     # configure home-manager
@@ -87,7 +87,7 @@ nixosSystem (recursiveUpdate args' {
         globalModules
         # include the home-manager modules
         ++ hmModules
-        # include all Soxin modules
-        ++ (builtins.attrValues self.nixosModules);
+        # include Soxin modules
+        ++ (singleton self.nixosModules.soxin);
     });
 })

--- a/lib/nixos-system.nix
+++ b/lib/nixos-system.nix
@@ -79,7 +79,7 @@ nixosSystem (recursiveUpdate args' {
       }
       # include the global special arguments.
       // globalSpecialArgs
-      # include the NixOS special arguments.
+      # include the home-manager special arguments.
       // hmSpecialArgs;
 
       home-manager.sharedModules =
@@ -87,7 +87,7 @@ nixosSystem (recursiveUpdate args' {
         globalModules
         # include the home-manager modules
         ++ hmModules
-        # include Soxin modules
+        # include Soxin module
         ++ (singleton self.nixosModules.soxin);
     });
 })

--- a/lib/nixos-system.nix
+++ b/lib/nixos-system.nix
@@ -56,7 +56,7 @@ nixosSystem (recursiveUpdate args' {
     # include the NixOS modules
     ++ nixosModules
     # include Soxin modules
-    ++ (singleton self.nixosModules.soxin)
+    ++ self.nixosModule
     # include home-manager modules
     ++ (singleton home-manager.nixosModules.home-manager)
     # configure Nix registry so users can find soxin
@@ -88,6 +88,6 @@ nixosSystem (recursiveUpdate args' {
         # include the home-manager modules
         ++ hmModules
         # include Soxin module
-        ++ (singleton self.nixosModules.soxin);
+        ++ self.nixosModule;
     });
 })


### PR DESCRIPTION
The HM flake has been updated to allow setting special arguments as well as modules directly through the `home-manager` top-level option. This PR takes advantage of that and allows setting special arguments and modules globally, per NixOS and per HM configuration.

NOTE: This requires updated your soxincfg to reflect the change of modules -> globalModules.
NOTE: This was extracted from #29 and tested only in that branch.