### PR TITLE
soxin: inherit the plugins option as-is from home-manager

### DIFF
--- a/lib/modules/neovim.nix
+++ b/lib/modules/neovim.nix
@@ -1,4 +1,4 @@
-{ nixpkgs, ... }:
+{ nixpkgs, home-manager, ... }:
 
 let
   inherit (nixpkgs) lib;
@@ -8,25 +8,13 @@ let
     types
     ;
 
+  hmModuleEval = home-manager.homeManagerConfiguration {
+    configuration = { };
+    username = "foo";
+    pkgs = nixpkgs;
+    check = false;
+  };
 in
 {
-  # TODO: Bring this from home-manager!
-  pluginWithConfigModule = types.submodule {
-    options = {
-      config = mkOption {
-        type = types.lines;
-        description = "vimscript for this plugin to be placed in init.vim";
-        default = "";
-      };
-
-      optional = mkEnableOption "optional" // {
-        description = "Don't load by default (load with :packadd)";
-      };
-
-      plugin = mkOption {
-        type = types.package;
-        description = "vim plugin";
-      };
-    };
-  };
+  pluginWithConfigModule = hmModuleEval.options.programs.neovim.plugins.type;
 }

--- a/lib/modules/neovim.nix
+++ b/lib/modules/neovim.nix
@@ -14,7 +14,7 @@ let
       system = "x86_64-linux";
 
       # username also don't matter here.
-      username = "nouser";
+      username = "nobody";
     in
     home-manager.lib.homeManagerConfiguration {
       inherit system username;

--- a/lib/modules/neovim.nix
+++ b/lib/modules/neovim.nix
@@ -8,12 +8,19 @@ let
     types
     ;
 
-  hmModuleEval = home-manager.lib.homeManagerConfiguration {
-    system = "x86_64-linux"; # system don't matter here, we just need the type of the plugins option.
-    configuration = { };
-    username = "nouser";
-    homeDirectory = "/home/nouser";
-    pkgs = builtins.getAttr system nixpkgs.outputs.legacyPackages;
-  };
+  hmModuleEval =
+    let
+      # system don't matter here, we just need the type of the plugins option.
+      system = "x86_64-linux";
+
+      # username also don't matter here.
+      username = "nouser";
+    in
+    home-manager.lib.homeManagerConfiguration {
+      inherit system username;
+      configuration = { };
+      homeDirectory = "/home/${username}";
+      pkgs = builtins.getAttr system nixpkgs.outputs.legacyPackages;
+    };
 in
 { pluginWithConfigModule = hmModuleEval.options.programs.neovim.plugins.type; }

--- a/lib/modules/neovim.nix
+++ b/lib/modules/neovim.nix
@@ -8,11 +8,12 @@ let
     types
     ;
 
-  hmModuleEval = home-manager.homeManagerConfiguration {
+  hmModuleEval = home-manager.lib.homeManagerConfiguration rec {
+    system="x86_64-linux";
     configuration = { };
-    username = "foo";
-    pkgs = nixpkgs;
-    check = false;
+    username = "nouser";
+    homeDirectory="/home/nouser";
+    pkgs = builtins.getAttr system nixpkgs.outputs.legacyPackages;
   };
 in
 {

--- a/lib/modules/neovim.nix
+++ b/lib/modules/neovim.nix
@@ -8,14 +8,12 @@ let
     types
     ;
 
-  hmModuleEval = home-manager.lib.homeManagerConfiguration rec {
-    system="x86_64-linux";
+  hmModuleEval = home-manager.lib.homeManagerConfiguration {
+    system = "x86_64-linux"; # system don't matter here, we just need the type of the plugins option.
     configuration = { };
     username = "nouser";
-    homeDirectory="/home/nouser";
+    homeDirectory = "/home/nouser";
     pkgs = builtins.getAttr system nixpkgs.outputs.legacyPackages;
   };
 in
-{
-  pluginWithConfigModule = hmModuleEval.options.programs.neovim.plugins.type;
-}
+{ pluginWithConfigModule = hmModuleEval.options.programs.neovim.plugins.type; }

--- a/lib/modules/themes.nix
+++ b/lib/modules/themes.nix
@@ -102,7 +102,7 @@ rec {
     options = {
       # TODO: Get this directly from home-manager instead of copying it
       plugins = mkOption {
-        type = listOf (either package neovim.pluginWithConfigModule);
+        type = neovim.pluginWithConfigModule;
         default = [ ];
         example = literalExample ''
           with pkgs.vimPlugins; [

--- a/lib/modules/themes.nix
+++ b/lib/modules/themes.nix
@@ -100,7 +100,6 @@ rec {
 
   neovimModule = with types; submodule {
     options = {
-      # TODO: Get this directly from home-manager instead of copying it
       plugins = mkOption {
         type = neovim.pluginWithConfigModule;
         default = [ ];

--- a/modules/programs/neovim/default.nix
+++ b/modules/programs/neovim/default.nix
@@ -2,6 +2,8 @@
 
 with lib;
 let
+  inherit (soxin.lib.modules) neovim;
+
   cfg = config.soxin.programs.neovim;
 in
 {
@@ -25,7 +27,7 @@ in
         };
 
         plugins = mkOption {
-          type = with types; listOf (either package soxin.lib.modules.neovim.pluginWithConfigModule);
+          type = neovim.pluginWithConfigModule;
           default = [ ];
           defaultText = "The plugins added by the theme";
           example = literalExample ''


### PR DESCRIPTION
Instead of copy/paste the type of the neovim.plugins option from home-manager, import home-manager, and extract the type we need from it.