### PR TITLE
rbrowser: fix the pkg on 22.05

### DIFF
--- a/pkgs/rbrowser/default.nix
+++ b/pkgs/rbrowser/default.nix
@@ -291,12 +291,25 @@ let
     );
 
   desktopItem = makeDesktopItem {
-    categories = "GTK;Network;WebBrowser;";
+    categories = [
+      "GTK"
+      "Network"
+      "WebBrowser"
+    ];
     desktopName = "Relay Browser";
     exec = "rbrowser %U";
     genericName = "Web Browser";
     icon = "chromium";
-    mimeType = "x-scheme-handler/unknown;x-scheme-handler/about;text/html;text/xml;application/xhtml+xml;text/mml;x-scheme-handler/http;x-scheme-handler/https;";
+    mimeTypes = [
+      "application/xhtml+xml"
+      "text/html"
+      "text/mml"
+      "text/xml"
+      "x-scheme-handler/about"
+      "x-scheme-handler/http"
+      "x-scheme-handler/https"
+      "x-scheme-handler/unknown"
+    ];
     name = "rbrowser";
   };
 in


### PR DESCRIPTION
The makeDesktopItem API has changed in NixOS/nixpkgs@0c713dbed40dd87090a4632cffc7b088653f35cb. This PR updates our use to fix it.