### PR TITLE
programs.rofi: dpi is an integer not a string

### DIFF
--- a/modules/programs/rofi/default.nix
+++ b/modules/programs/rofi/default.nix
@@ -51,7 +51,6 @@ in
           type = with types; nullOr ints.positive;
           default = null;
           description = "The DPI of the rofi.";
-          apply = value: toString value;
         };
       };
     };
@@ -73,9 +72,9 @@ in
 
         theme = cfg.theme.name;
 
-        extraConfig = {
-          inherit (cfg) modi dpi;
-        };
+        extraConfig =
+          { inherit (cfg) modi; }
+          // (optionalAttrs (cfg.dpi != null) { inherit (cfg) dpi; });
 
         font = "Source Code Pro for Powerline 9";
       };


### PR DESCRIPTION
The dpi in string format was deprecated in 21.11 and removed in 22.05. This change is required for supporting 22.05.