### PR TITLE
programs.neovim: add options for RC header/footer and mapleader

### DIFF
--- a/modules/programs/neovim/default.nix
+++ b/modules/programs/neovim/default.nix
@@ -138,16 +138,10 @@ in
       // (genAttrs [ "withNodeJs" "withPython3" "withRuby" ] (name: true));
 
       # inject the header/footer to the rcfile on home-manager
-      xdg.configFile."nvim/init.vim".text = mkForce (builtins.concatStringsSep "\n" [
-        cfg.rcheader
-        config.programs.neovim.generatedConfigViml
-        cfg.rcfooter
-      ]);
-      # TODO: The above should work, and is better as below. Why no work?
-      # xdg.configFile."nvim/init.vim" = mkMerge [
-      #   (mkBefore { text = cfg.rcheader; })
-      #   (mkAfter { text = cfg.rcfooter; })
-      # ];
+      xdg.configFile."nvim/init.vim".text = mkMerge [
+        (mkBefore cfg.rcheader)
+        (mkAfter cfg.rcfooter)
+      ];
     })
   ]);
 }


### PR DESCRIPTION
When configuring plugins, one can't make use of `<leader>` because it's not possible to configure the `mapleader` ahead of the plugins. I've added options for adding random lines to the top/bottom of the rc file, and I added another option for just the mapleader character, and it itself will inject the code in the header.