### PR TITLE
neovim: adjust homeManagerConfiguration after its 22.11 release

### DIFF
--- a/lib/modules/neovim.nix
+++ b/lib/modules/neovim.nix
@@ -17,10 +17,14 @@ let
       username = "nobody";
     in
     home-manager.lib.homeManagerConfiguration {
-      inherit system username;
-      configuration = { };
-      homeDirectory = "/home/${username}";
       pkgs = builtins.getAttr system nixpkgs.outputs.legacyPackages;
+      modules = [{
+        home = {
+          inherit username;
+          stateVersion = "22.11";
+          homeDirectory = "/home/${username}";
+        };
+      }];
     };
 in
 { pluginWithConfigModule = hmModuleEval.options.programs.neovim.plugins.type; }


### PR DESCRIPTION
Home Manager has changed the signature of its homeManagerConfiguration function; see its [release notes](https://nix-community.github.io/home-manager/release-notes.html#sec-release-22.11).