### PR TITLE
lib: homeManagerConfiguration: Make it work with upstream changes

### DIFF
--- a/lib/home-manager-configuration.nix
+++ b/lib/home-manager-configuration.nix
@@ -8,7 +8,7 @@
 , modules ? [ ]
 
   # Home-manager specific extra arguments.
-, hmSpecialArgs ? { }
+, specialArgs ? { }
 
   # What packages to use?
 , pkgs ? inputs.nixpkgs.legacyPackages."${system}"
@@ -31,7 +31,7 @@ let
   soxincfg = inputs.self;
 
   otherArguments = removeAttrs args [
-    "hmSpecialArgs"
+    "specialArgs"
     "inputs"
     "modules"
     "overlays"
@@ -53,7 +53,7 @@ let
         mode = "home-manager";
       }
       # include the home-manager special arguments.
-      // hmSpecialArgs;
+      // specialArgs;
 
       modules =
         modules

--- a/lib/home-manager-configuration.nix
+++ b/lib/home-manager-configuration.nix
@@ -4,18 +4,11 @@
   # inputs of your own soxincfg
   inputs
 
-  # The configuration to build with home-manager.
-, configuration
-
-  # The username and the absolute path to their home directory.
-, username
-, homeDirectory
-
-  # What system to build for?
-, system
+# TODO: comment
+, pkgs
 
   # Home-manager specific modules.
-, hmModules ? [ ]
+, modules ? [ ]
 
   # Home-manager specific extra arguments.
 , hmSpecialArgs ? { }
@@ -34,7 +27,6 @@ let
   otherArguments = removeAttrs args [
     "inputs"
     "hmSpecialArgs"
-    "hmModules"
   ];
 
 in
@@ -48,11 +40,9 @@ home-manager.lib.homeManagerConfiguration (recursiveUpdate
   # include the home-manager special arguments.
   // hmSpecialArgs;
 
-  extraModules =
-    # include the home-manager modules
-    hmModules
+  modules =
     # include Soxin module
-    ++ (singleton soxin.nixosModules.soxin)
+    (singleton soxin.nixosModules.soxin)
     # include SoxinCFG module
     ++ (singleton soxincfg.nixosModules.soxincfg);
 }

--- a/lib/home-manager-configuration.nix
+++ b/lib/home-manager-configuration.nix
@@ -13,6 +13,9 @@
   # What packages to use?
 , pkgs ? inputs.nixpkgs.legacyPackages."${system}"
 
+  # Define the overlays to apply to pkgs
+, overlays ? [ ]
+
   # What system to build for?
 , system
 
@@ -31,13 +34,18 @@ let
     "hmSpecialArgs"
     "inputs"
     "modules"
+    "overlays"
     "pkgs"
     "system"
   ];
 
   hmArgs = (recursiveUpdate
     {
-      inherit pkgs;
+      pkgs = import pkgs.path {
+        inherit (pkgs) config system;
+
+        overlays = pkgs.overlays ++ overlays;
+      };
 
       extraSpecialArgs = {
         inherit inputs soxin soxincfg;

--- a/lib/home-manager-configuration.nix
+++ b/lib/home-manager-configuration.nix
@@ -31,11 +31,11 @@ let
   soxincfg = inputs.self;
 
   otherArguments = removeAttrs args [
-    "specialArgs"
     "inputs"
     "modules"
     "overlays"
     "pkgs"
+    "specialArgs"
     "system"
   ];
 

--- a/lib/mk-flake.nix
+++ b/lib/mk-flake.nix
@@ -379,6 +379,8 @@ flake-utils-plus.lib.mkFlake (recursiveUpdate soxinSystemFlake otherArguments)
   // {
   homeConfigurations = (mapAttrs
     (_: host: soxin.lib.homeManagerConfiguration (host // {
+      inherit hmSpecialArgs;
+
       modules =
         host.modules
         # include the global modules

--- a/lib/mk-flake.nix
+++ b/lib/mk-flake.nix
@@ -380,9 +380,10 @@ flake-utils-plus.lib.mkFlake (recursiveUpdate soxinSystemFlake otherArguments)
   homeConfigurations = (mapAttrs
     (_: host: soxin.lib.homeManagerConfiguration (host // {
       inherit inputs;
-      hmModules =
+      modules =
+        host.modules
         # include the global modules
-        extraGlobalModules
+        ++ extraGlobalModules
         # include the home-manager modules
         ++ extraHomeManagerModules;
     }))

--- a/lib/mk-flake.nix
+++ b/lib/mk-flake.nix
@@ -379,7 +379,6 @@ flake-utils-plus.lib.mkFlake (recursiveUpdate soxinSystemFlake otherArguments)
   // {
   homeConfigurations = (mapAttrs
     (_: host: soxin.lib.homeManagerConfiguration (host // {
-      inherit inputs;
       modules =
         host.modules
         # include the global modules

--- a/lib/mk-flake.nix
+++ b/lib/mk-flake.nix
@@ -111,6 +111,18 @@ let
     "sharedOverlays"
   ];
 
+  # Overlays which are applied to all channels.
+  sharedOverlays' = [
+    # Overlay imported from this flake
+    self.overlay
+    # Nix User Repository overlay
+    nur.overlay
+  ]
+  # pass along the sharedModules
+  ++ sharedOverlays
+  # pass along sops-nix overlays.
+  ++ optionals withSops (singleton sops-nix.overlays.default);
+
   # generate each host by injecting special arguments and the given host
   # without certain soxin-only attributes.
   hosts' =
@@ -226,6 +238,9 @@ let
     # inherit the required fields as-is
     inherit inputs flake-utils-plus;
 
+    # Overlays which are applied to all channels.
+    sharedOverlays = sharedOverlays';
+
     # send self as soxincfg
     self = soxincfg;
 
@@ -235,18 +250,6 @@ let
     # configure the channels.
     channels.nixpkgs.input = nixpkgs;
     channels.nixpkgs-unstable.input = nixpkgs-unstable;
-
-    # Overlays which are applied to all channels.
-    sharedOverlays = [
-      # Overlay imported from this flake
-      self.overlay
-      # Nix User Repository overlay
-      nur.overlay
-    ]
-    # pass along the sharedModules
-    ++ sharedOverlays
-    # pass along sops-nix overlays.
-    ++ optionals withSops (singleton sops-nix.overlays.default);
 
     # TODO: Add support for modifying the outputsBuilder.
     outputsBuilder = channels:
@@ -387,6 +390,8 @@ flake-utils-plus.lib.mkFlake (recursiveUpdate soxinSystemFlake otherArguments)
         ++ extraGlobalModules
         # include the home-manager modules
         ++ extraHomeManagerModules;
+
+      overlays = sharedOverlays';
     }))
     home-managers);
 }

--- a/lib/mk-flake.nix
+++ b/lib/mk-flake.nix
@@ -382,7 +382,7 @@ flake-utils-plus.lib.mkFlake (recursiveUpdate soxinSystemFlake otherArguments)
   // {
   homeConfigurations = (mapAttrs
     (_: host: soxin.lib.homeManagerConfiguration (host // {
-      inherit hmSpecialArgs;
+      inherit hmSpecialArgs inputs;
 
       modules =
         host.modules

--- a/lib/mk-flake.nix
+++ b/lib/mk-flake.nix
@@ -38,7 +38,7 @@
   # nix-darwin specific modules.
 , extraNixDarwinModules ? [ ]
 
-  # The global extra arguments are included in both NixOS and home-manager.
+  # The global extra arguments are included everywhere.
 , globalSpecialArgs ? { }
 
   # Home-manager specific extra arguments.
@@ -382,7 +382,16 @@ flake-utils-plus.lib.mkFlake (recursiveUpdate soxinSystemFlake otherArguments)
   // {
   homeConfigurations = (mapAttrs
     (_: host: soxin.lib.homeManagerConfiguration (host // {
-      inherit hmSpecialArgs inputs;
+      inherit inputs;
+
+      specialArgs =
+        { }
+        # include the specialArgs that were passed in.
+        // (host.specialArgs or { })
+        # include the global special arguments.
+        // globalSpecialArgs
+        # include the home-manager special arguments.
+        // hmSpecialArgs;
 
       modules =
         host.modules


### PR DESCRIPTION
Recent [upstream changes][upstream-changes] have broken support for home-manager configurations. This PR fixes them.

[upstream-changes]: https://nix-community.github.io/home-manager/release-notes.xhtml#sec-release-22.11-highlights