### PR TITLE
lib/mk-flake: Pass host.specialArgs to home-manager

### DIFF
--- a/lib/mk-flake.nix
+++ b/lib/mk-flake.nix
@@ -142,7 +142,10 @@ let
                 ++ extraNixDarwinModules
                 # include home-manager modules
                 ++ (singleton home-manager.darwinModules.home-manager)
+                # configure home-manager with host-specific settings
+                ++ (singleton { home-manager.extraSpecialArgs = host.specialArgs; })
                 ;
+
                 specialArgs =
                   {
                     inherit
@@ -185,6 +188,8 @@ let
                 ++ (optionals withSops (singleton sops-nix.nixosModules.sops))
                 # include home-manager modules
                 ++ (singleton home-manager.nixosModules.home-manager)
+                # configure home-manager with host-specific settings
+                ++ (singleton { home-manager.extraSpecialArgs = host.specialArgs; })
               ;
 
               specialArgs =


### PR DESCRIPTION
Currently, NixOS and nix-darwin do not pass `host.specialArgs` down to home-manager. I discovered this as I was adding a new `mode`-like attribute named `hostType` to figure out what is calling it; I was relying on things like `isLinux` or `isDarwin` but I wanted to know if it's `NixOS` or just a plain `Linux` distribution which was not possible without this hostType. Anyways, it's not very relevant to this change, as this one just fixes the fact that home-manager running within NixOS or nix-darwin isn't receiving host-specific specialArgs.