### PR TITLE
programs/git: Improve the Git module

### DIFF
--- a/modules/programs/git/default.nix
+++ b/modules/programs/git/default.nix
@@ -12,6 +12,7 @@ let
     options = {
       key = mkOption {
         type = types.nullOr types.str;
+        default = null;
         description = ''
           The default GPG signing key fingerprint.
 

--- a/modules/programs/git/default.nix
+++ b/modules/programs/git/default.nix
@@ -1,10 +1,46 @@
 { mode, config, pkgs, lib, ... }:
 
-with lib;
 let
-  cfg = config.soxin.programs.git;
+  inherit (lib)
+    mkEnableOption
+    mkOption
+    optionals
+    types
+    ;
+
+  signModule = types.submodule {
+    options = {
+      key = mkOption {
+        type = types.nullOr types.str;
+        description = ''
+          The default GPG signing key fingerprint.
+
+          Set to `null` to let GnuPG decide what signing key
+          to use depending on commit’s author.
+        '';
+      };
+
+      signByDefault = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether commits and tags should be signed by default.";
+      };
+
+      gpgPath = mkOption {
+        type = types.str;
+        default = "${pkgs.gnupg}/bin/gpg2";
+        defaultText = "\${pkgs.gnupg}/bin/gpg2";
+        description = "Path to GnuPG binary to use.";
+      };
+    };
+  };
 in
 {
+  imports =
+    [ ]
+    ++ optionals (mode == "NixOS") [ ./nixos.nix ]
+    ++ optionals (mode == "home-manager") [ ./home.nix ];
+
   options = {
     soxin.programs.git = {
       enable = mkEnableOption "git";
@@ -28,36 +64,14 @@ in
         description = "git user email";
       };
 
-      gpgSigningKey = mkOption {
-        type = with types; nullOr str;
+      signing = mkOption {
+        type = types.nullOr signModule;
         default = null;
-        description = "git PGP signing key";
+        description = "Options related to signing commits using GnuPG.";
       };
 
       lfs.enable = mkEnableOption "Enable git.lfs";
     };
   };
-
-  config = mkIf cfg.enable (mkMerge [
-    (optionalAttrs (mode == "NixOS") {
-      # TODO: NixOS does not currently mirror home-manager
-      environment.systemPackages = [ cfg.package ];
-    })
-
-    (optionalAttrs (mode == "home-manager") {
-      programs.git = {
-        inherit (cfg) package userName userEmail;
-
-        enable = true;
-
-        signing = mkIf (cfg.gpgSigningKey != null) {
-          key = cfg.gpgSigningKey;
-          signByDefault = mkDefault true;
-        };
-
-        lfs = { inherit (cfg.lfs) enable; };
-      };
-    })
-  ]);
 }
 

--- a/modules/programs/git/home.nix
+++ b/modules/programs/git/home.nix
@@ -1,0 +1,18 @@
+{ config, lib, ... }:
+
+let
+  inherit (lib)
+    mkIf
+    ;
+
+  cfg = config.soxin.programs.git;
+in
+{
+  config = mkIf cfg.enable {
+    programs.git = {
+      inherit (cfg) enable package signing userName userEmail;
+
+      lfs = { inherit (cfg.lfs) enable; };
+    };
+  };
+}

--- a/modules/programs/git/nixos.nix
+++ b/modules/programs/git/nixos.nix
@@ -2,40 +2,40 @@
 
 let
   inherit (lib)
+    mkDefault
     mkIf
+    mkMerge
     ;
 
   cfg = config.soxin.programs.git;
+
 in
 {
   config = mkIf cfg.enable {
-    programs.git = {
-      inherit (cfg) enable package;
+    programs.git = mkMerge [
+      {
+        inherit (cfg) enable package;
 
-      config = [
-        (mkIf (cfg.signing != null) {
-          user.signingKey = mkIf (cfg.signing.key != null) cfg.signing.key;
-          commit.gpgSign = mkDefault cfg.signing.signByDefault;
-          tag.gpgSign = mkDefault cfg.signing.signByDefault;
-          gpg.program = cfg.signing.gpgPath;
-        })
+        lfs = { inherit (cfg.lfs) enable; };
+      }
 
-        (mkIf (cfg.userName != null) {
-          user = {
-            name = cfg.userName;
-          };
-        })
+      (mkIf (cfg.signing != null) {
+        config.commit.gpgSign = mkDefault cfg.signing.signByDefault;
+        config.tag.gpgSign = mkDefault cfg.signing.signByDefault;
+        config.gpg.program = cfg.signing.gpgPath;
+      })
 
-        (mkIf (cfg.userEmail != null) {
-          user = {
-            email = cfg.userEmail;
-          };
-        })
-      ];
+      (mkIf (cfg.signing != null && cfg.signing.key != null) {
+        config.user.signingKey = cfg.signing.key;
+      })
 
-      lfs = { inherit (cfg.lfs) enable; };
+      (mkIf (cfg.userName != null) {
+        config.user.name = cfg.userName;
+      })
 
-      signing = cfg.signing;
-    };
+      (mkIf (cfg.userEmail != null) {
+        config.user.email = cfg.userEmail;
+      })
+    ];
   };
 }

--- a/modules/programs/git/nixos.nix
+++ b/modules/programs/git/nixos.nix
@@ -1,0 +1,41 @@
+{ config, lib, ... }:
+
+let
+  inherit (lib)
+    mkIf
+    ;
+
+  cfg = config.soxin.programs.git;
+in
+{
+  config = mkIf cfg.enable {
+    programs.git = {
+      inherit (cfg) enable package;
+
+      config = [
+        (mkIf (cfg.signing != null) {
+          user.signingKey = mkIf (cfg.signing.key != null) cfg.signing.key;
+          commit.gpgSign = mkDefault cfg.signing.signByDefault;
+          tag.gpgSign = mkDefault cfg.signing.signByDefault;
+          gpg.program = cfg.signing.gpgPath;
+        })
+
+        (mkIf (cfg.userName != null) {
+          user = {
+            name = cfg.userName;
+          };
+        })
+
+        (mkIf (cfg.userEmail != null) {
+          user = {
+            email = cfg.userEmail;
+          };
+        })
+      ];
+
+      lfs = { inherit (cfg.lfs) enable; };
+
+      signing = cfg.signing;
+    };
+  };
+}


### PR DESCRIPTION
- Split `default.nix` into `home.nix` and `nixos.nix`
- Follow home-manager's signing configuration.
- Improve the NixOS integration by using the now-available `programs.git` configuration

Tested platforms:
- [x] Test on NixOS
- [x] Test on Qubes