### PR TITLE
treewide: fixes for NixOS 24.11

### DIFF
--- a/modules/programs/rbrowser/default.nix
+++ b/modules/programs/rbrowser/default.nix
@@ -120,12 +120,12 @@ in
 
       package = mkOption {
         type = types.package;
-        default = rbrowser.override { inherit (cfg) browsers; };
+        default = rbrowser.override { configuredBrowsers = cfg.browsers; };
         defaultText = ''
-          pkgs.soxin.rbrowser.override { inherit (cfg) browsers; };
+          pkgs.soxin.rbrowser.override { configuredBrowsers = cfg.browsers; };
         '';
         example = ''
-          pkgs.soxin.rbrowser.override { browsers = [ { name = "chromium"; profile = "personal"; flags = []; } ]; };
+          pkgs.soxin.rbrowser.override { configuredBrowsers = [ { name = "chromium"; profile = "personal"; flags = []; } ]; };
         '';
         description = ''
           The rbrowser package to use. It it automatically overriden depending

--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -115,7 +115,9 @@ in
 
     (optionalAttrs (mode == "home-manager") {
       programs.zsh = {
-        inherit (cfg) enableAutosuggestions plugins;
+        inherit (cfg) plugins;
+
+        autosuggestion.enable = cfg.enableAutosuggestions;
       };
     })
 

--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -114,9 +114,7 @@ in
     })
 
     (optionalAttrs (mode == "home-manager") {
-      programs.zsh = {
-        inherit (cfg) enableAutosuggestions plugins;
-      };
+      programs.zsh.autosuggestions.enable = cfg.enableAutosuggestions;
     })
 
     # install all completions libraries for system packages

--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -114,7 +114,9 @@ in
     })
 
     (optionalAttrs (mode == "home-manager") {
-      programs.zsh.autosuggestions.enable = cfg.enableAutosuggestions;
+      programs.zsh = {
+        inherit (cfg) enableAutosuggestions plugins;
+      };
     })
 
     # install all completions libraries for system packages

--- a/modules/settings/keyboard.nix
+++ b/modules/settings/keyboard.nix
@@ -81,8 +81,8 @@ in
       };
 
       services.xserver = {
-        layout = concatMapStringsSep "," (l: l.x11.layout) cfg.layouts;
-        xkbVariant = concatMapStringsSep "," (l: l.x11.variant) cfg.layouts;
+        xkb.layout = concatMapStringsSep "," (l: l.x11.layout) cfg.layouts;
+        xkb.variant = concatMapStringsSep "," (l: l.x11.variant) cfg.layouts;
       };
     })
 

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -6,7 +6,7 @@
 }:
 
 let
-  inherit (lib) findSingle filterAttrs platforms;
+  inherit (lib) findSingle filterAttrs;
 
   pkgs = {
     rbrowser = callPackage ./rbrowser { };

--- a/pkgs/rbrowser/default.nix
+++ b/pkgs/rbrowser/default.nix
@@ -10,7 +10,7 @@
   vivaldi,
   writeScriptBin,
 
-  browsers ? [
+  configuredBrowsers ? [
     {
       name = "brave";
       profile = "default";
@@ -33,6 +33,7 @@
     }
   ],
 }:
+
 let
   # What are the supported browsers by Rbrowser?
   supportedBrowsers = [
@@ -56,7 +57,7 @@ let
     in
     browser:
     let
-      mb = builtins.length (matchBrowsers browsers browser);
+      mb = builtins.length (matchBrowsers configuredBrowsers browser);
     in
     mb >= 1;
   withBrave = withBrowser "brave";
@@ -67,7 +68,7 @@ let
   rbrowser = writeScriptBin "rbrowser" (
     let
       items = builtins.concatStringsSep "\n" (
-        map (browser: ''"${browser.name}@${browser.profile}"'') browsers
+        map (browser: ''"${browser.name}@${browser.profile}"'') configuredBrowsers
       );
 
       declareFlags = builtins.concatStringsSep "\n" (
@@ -75,7 +76,7 @@ let
           if [[ "$browser" == "${b.name}" ]] && [[ "$profile" == "${b.profile}" ]]; then
             args=(''${args[@]} ${builtins.concatStringsSep " " (map (f: ''"${f}"'') b.flags)})
           fi
-        '') (builtins.filter (b: b.flags != [ ]) browsers)
+        '') (builtins.filter (b: b.flags != [ ]) configuredBrowsers)
       );
     in
     ''
@@ -347,7 +348,7 @@ in
 assert lib.asserts.assertMsg (
   withBrave || withChromium || withFirefox || withVivaldi
 ) "At least one browser must be enabled.";
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation {
   name = "rbrowser";
 
   src = rbrowser;
@@ -360,7 +361,7 @@ stdenvNoCC.mkDerivation rec {
   '';
 
   passthru = {
-    inherit supportedBrowsers;
+    inherit configuredBrowsers supportedBrowsers;
   };
 
   meta =


### PR DESCRIPTION
- Fix the rbrowser package by renaming the browser arg as it now exists [as a package in NixOS](https://search.nixos.org/packages?channel=24.11&from=0&size=50&sort=relevance&type=packages&query=browsers).
- Fix deprecation warnings.

depends on #67 