### PR TITLE
lib/mk-flake: expect channels and inputs to come in arguments

### DIFF
--- a/lib/mk-flake.nix
+++ b/lib/mk-flake.nix
@@ -3,8 +3,6 @@
   deploy-rs,
   home-manager,
   flake-utils-plus,
-  nixpkgs,
-  nixpkgs-unstable,
   nur,
   self,
   sops-nix,
@@ -14,6 +12,9 @@
 {
   # inputs of your own soxincfg
   inputs,
+
+  # channels configuration
+  channels ? { },
 
   # attr attribute set of hosts
   # See https://github.com/gytis-ivaskevicius/flake-utils-plus/blob/e7ae270a23695b50fbb6b72759a7fb1e3340ca86/examples/fully-featured/flake.nix#L101-L112
@@ -72,10 +73,17 @@
 }@args:
 
 let
+  assertMsg = pred: msg: pred || builtins.throw msg;
+in
+assert assertMsg (
+  channels ? "nixpkgs" && channels.nixpkgs ? "input"
+) "You must pass in channels.nixpkgs.input";
+
+let
   soxin = self;
   soxincfg = inputs.self;
 
-  inherit (nixpkgs) lib;
+  inherit (channels.nixpkgs.input) lib;
 
   inherit (lib)
     asserts
@@ -255,10 +263,6 @@ let
 
       # set the hosts
       hosts = hosts';
-
-      # configure the channels.
-      channels.nixpkgs.input = nixpkgs;
-      channels.nixpkgs-unstable.input = nixpkgs-unstable;
 
       # TODO: Add support for modifying the outputsBuilder.
       outputsBuilder =

--- a/template/flake.nix
+++ b/template/flake.nix
@@ -42,6 +42,7 @@
       flake-utils-plus,
       nixos-hardware,
       nixpkgs,
+      nixpkgs-unstable,
       self,
       soxin,
       ...
@@ -54,12 +55,14 @@
       withSops = true;
 
       inherit (nixpkgs) lib;
-      inherit (lib) optionalAttrs recursiveUpdate singleton;
+      inherit (lib) optionalAttrs;
       inherit (flake-utils-plus.lib) flattenTree;
 
       # Channel definitions. `channels.<name>.{input,overlaysBuilder,config,patches}`
       channels = {
         nixpkgs = {
+          input = nixpkgs;
+
           # Channel specific overlays
           overlaysBuilder = channels: [ (final: prev: { }) ];
 
@@ -68,6 +71,10 @@
 
           # Yep, you see it first folks - you can patch nixpkgs!
           patches = [ ];
+        };
+
+        nixpkgs-unstable = {
+          input = nixpkgs-unstable;
         };
       };
 


### PR DESCRIPTION
Soxin was declaring the channels internally given the inputs but that was overriding settings in soxincfg and I couldn't pass in patches to nixpkgs. Instead of hardcode the channels, let the caller decide on them.