### PR TITLE
fix(git): Fix the programs.git.signing option

### DIFF
--- a/modules/programs/git/default.nix
+++ b/modules/programs/git/default.nix
@@ -13,50 +13,6 @@ let
     optionals
     types
     ;
-
-  signModule = types.submodule {
-    options = {
-      key = mkOption {
-        type = types.nullOr types.str;
-        default = null;
-        description = ''
-          The default signing key fingerprint.
-
-          Set to `null` to let the signer decide what signing key
-          to use depending on commit’s author.
-        '';
-      };
-
-      format = mkOption {
-        type = types.nullOr (
-          types.enum [
-            "openpgp"
-            "ssh"
-            "x509"
-          ]
-        );
-        defaultText = literalExpression ''
-          "openpgp" for state version < 25.05,
-          undefined for state version ≥ 25.05
-        '';
-        description = ''
-          The signing method to use when signing commits and tags.
-          Valid values are `openpgp` (OpenPGP/GnuPG), `ssh` (SSH), and `x509` (X.509 certificates).
-        '';
-      };
-
-      signByDefault = mkOption {
-        type = types.nullOr types.bool;
-        default = null;
-        description = "Whether commits and tags should be signed by default.";
-      };
-
-      signer = mkOption {
-        type = types.nullOr types.str;
-        description = "Path to signer binary to use.";
-      };
-    };
-  };
 in
 {
   imports =
@@ -87,10 +43,46 @@ in
         description = "git user email";
       };
 
-      signing = mkOption {
-        type = signModule;
-        default = { };
-        description = "Options related to signing commits using GnuPG.";
+      signing = {
+        key = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          description = ''
+            The default signing key fingerprint.
+
+            Set to `null` to let the signer decide what signing key
+            to use depending on commit’s author.
+          '';
+        };
+
+        format = mkOption {
+          type = types.nullOr (
+            types.enum [
+              "openpgp"
+              "ssh"
+              "x509"
+            ]
+          );
+          defaultText = literalExpression ''
+            "openpgp" for state version < 25.05,
+            undefined for state version ≥ 25.05
+          '';
+          description = ''
+            The signing method to use when signing commits and tags.
+            Valid values are `openpgp` (OpenPGP/GnuPG), `ssh` (SSH), and `x509` (X.509 certificates).
+          '';
+        };
+
+        signByDefault = mkOption {
+          type = types.nullOr types.bool;
+          default = null;
+          description = "Whether commits and tags should be signed by default.";
+        };
+
+        signer = mkOption {
+          type = types.nullOr types.str;
+          description = "Path to signer binary to use.";
+        };
       };
 
       lfs.enable = mkEnableOption "Enable git.lfs";

--- a/modules/programs/git/home.nix
+++ b/modules/programs/git/home.nix
@@ -1,7 +1,7 @@
 { config, lib, ... }:
 
 let
-  inherit (lib) mkIf;
+  inherit (lib) mkIf mkMerge;
 
   cfg = config.soxin.programs.git;
 in
@@ -11,7 +11,6 @@ in
       inherit (cfg)
         enable
         package
-        signing
         userName
         userEmail
         ;
@@ -19,6 +18,16 @@ in
       lfs = {
         inherit (cfg.lfs) enable;
       };
+
+      signing = mkMerge [
+        (mkIf (cfg.signing.key != null) { inherit (cfg.signing) key; })
+
+        (mkIf (cfg.signing.format != null) { inherit (cfg.signing) format; })
+
+        (mkIf (cfg.signing.signByDefault != null) { inherit (cfg.signing) signByDefault; })
+
+        (mkIf (cfg.signing.signer != null) { inherit (cfg.signing) signer; })
+      ];
     };
   };
 }

--- a/modules/programs/git/home.nix
+++ b/modules/programs/git/home.nix
@@ -1,24 +1,57 @@
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 let
-  inherit (lib) mkIf;
+  inherit (lib)
+    mkDefault
+    mkIf
+    mkMerge
+    mkOptionDefault
+    ;
 
   cfg = config.soxin.programs.git;
 in
 {
-  config = mkIf cfg.enable {
-    programs.git = {
-      inherit (cfg)
-        enable
-        package
-        signing
-        userName
-        userEmail
-        ;
-
-      lfs = {
-        inherit (cfg.lfs) enable;
+  config = mkMerge [
+    (mkIf (cfg.signing != { }) {
+      soxin.programs.git = {
+        signing = {
+          format =
+            if (lib.versionOlder config.home.stateVersion "25.05") then
+              (mkOptionDefault "openpgp")
+            else
+              (mkOptionDefault null);
+          signer =
+            let
+              defaultSigners = {
+                openpgp = lib.getExe config.programs.gpg.package;
+                ssh = lib.getExe' pkgs.openssh "ssh-keygen";
+                x509 = lib.getExe' config.programs.gpg.package "gpgsm";
+              };
+            in
+            mkIf (cfg.signing.format != null) (mkOptionDefault defaultSigners.${cfg.signing.format});
+        };
       };
-    };
-  };
+    })
+
+    (mkIf cfg.enable {
+      programs.git = {
+        inherit (cfg)
+          enable
+          package
+          signing
+          userName
+          userEmail
+          ;
+
+        lfs = {
+          inherit (cfg.lfs) enable;
+        };
+      };
+    })
+  ];
 }

--- a/modules/programs/git/home.nix
+++ b/modules/programs/git/home.nix
@@ -6,12 +6,7 @@
 }:
 
 let
-  inherit (lib)
-    mkDefault
-    mkIf
-    mkMerge
-    mkOptionDefault
-    ;
+  inherit (lib) mkIf mkMerge mkOptionDefault;
 
   cfg = config.soxin.programs.git;
 in

--- a/modules/programs/git/home.nix
+++ b/modules/programs/git/home.nix
@@ -1,7 +1,7 @@
 { config, lib, ... }:
 
 let
-  inherit (lib) mkIf mkMerge;
+  inherit (lib) mkIf;
 
   cfg = config.soxin.programs.git;
 in
@@ -11,6 +11,7 @@ in
       inherit (cfg)
         enable
         package
+        signing
         userName
         userEmail
         ;
@@ -18,16 +19,6 @@ in
       lfs = {
         inherit (cfg.lfs) enable;
       };
-
-      signing = mkMerge [
-        (mkIf (cfg.signing.key != null) { inherit (cfg.signing) key; })
-
-        (mkIf (cfg.signing.format != null) { inherit (cfg.signing) format; })
-
-        (mkIf (cfg.signing.signByDefault != null) { inherit (cfg.signing) signByDefault; })
-
-        (mkIf (cfg.signing.signer != null) { inherit (cfg.signing) signer; })
-      ];
     };
   };
 }

--- a/modules/programs/git/nixos.nix
+++ b/modules/programs/git/nixos.nix
@@ -1,35 +1,72 @@
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 let
-  inherit (lib) mkDefault mkIf mkMerge;
+  inherit (lib)
+    mkDefault
+    mkIf
+    mkMerge
+    mkOptionDefault
+    ;
 
   cfg = config.soxin.programs.git;
 
 in
 {
-  config = mkIf cfg.enable {
-    programs.git = mkMerge [
-      {
+  config = mkMerge [
+    (mkIf (cfg.signing != { }) {
+      soxin.programs.git = {
+        signing = {
+          format =
+            if (lib.versionOlder config.system.stateVersion "25.05") then
+              (mkOptionDefault "openpgp")
+            else
+              (mkOptionDefault null);
+          signer =
+            let
+              defaultSigners = {
+                openpgp = lib.getExe config.programs.gpg.package;
+                ssh = lib.getExe' pkgs.openssh "ssh-keygen";
+                x509 = lib.getExe' config.programs.gpg.package "gpgsm";
+              };
+            in
+            mkIf (cfg.signing.format != null) (mkOptionDefault defaultSigners.${cfg.signing.format});
+        };
+      };
+
+      programs.git.config = mkMerge [
+        (mkIf (cfg.signing.key != null) { user.signingKey = mkDefault cfg.signing.key; })
+        (mkIf (cfg.signing.signByDefault != null) {
+          commit.gpgSign = mkDefault cfg.signing.signByDefault;
+          tag.gpgSign = mkDefault cfg.signing.signByDefault;
+        })
+        (mkIf (cfg.signing.format != null) {
+          gpg = {
+            format = mkDefault cfg.signing.format;
+            ${cfg.signing.format}.program = mkDefault cfg.signing.signer;
+          };
+        })
+      ];
+    })
+
+    (mkIf cfg.enable {
+      programs.git = {
         inherit (cfg) enable package;
 
         lfs = {
           inherit (cfg.lfs) enable;
         };
-      }
 
-      (mkIf (cfg.signing != null) {
-        config.commit.gpgSign = mkDefault cfg.signing.signByDefault;
-        config.tag.gpgSign = mkDefault cfg.signing.signByDefault;
-        config.gpg.program = cfg.signing.gpgPath;
-      })
+        config = mkMerge [
+          (mkIf (cfg.userName != null) { user.name = cfg.userName; })
 
-      (mkIf (cfg.signing != null && cfg.signing.key != null) {
-        config.user.signingKey = cfg.signing.key;
-      })
-
-      (mkIf (cfg.userName != null) { config.user.name = cfg.userName; })
-
-      (mkIf (cfg.userEmail != null) { config.user.email = cfg.userEmail; })
-    ];
-  };
+          (mkIf (cfg.userEmail != null) { user.email = cfg.userEmail; })
+        ];
+      };
+    })
+  ];
 }

--- a/modules/programs/git/nixos.nix
+++ b/modules/programs/git/nixos.nix
@@ -29,9 +29,9 @@ in
           signer =
             let
               defaultSigners = {
-                openpgp = lib.getExe config.programs.gpg.package;
+                openpgp = lib.getExe config.programs.gnupg.package;
                 ssh = lib.getExe' pkgs.openssh "ssh-keygen";
-                x509 = lib.getExe' config.programs.gpg.package "gpgsm";
+                x509 = lib.getExe' config.programs.gnupg.package "gpgsm";
               };
             in
             mkIf (cfg.signing.format != null) (mkOptionDefault defaultSigners.${cfg.signing.format});


### PR DESCRIPTION
I was getting this error building my hosts:

```
error: expected a set but found null: null
```

It took me a while to trace the issue but I finally figured out it's coming from home-manager's `programs.git.signing` that defaulted to null but it's no longer a submodule upstream instead it's expected to be an attribute set.